### PR TITLE
fix-typo/MFC-1

### DIFF
--- a/MFC.md
+++ b/MFC.md
@@ -10,7 +10,7 @@ is `freebsd` as suggested in other docs.
 Git gives some help for committing cherry picks and keeping track. Git computes a 'diff index' for each commit that's applied and uses that to detect when it
 doesn't need to include the patch in a rebase, or as part of git log --cherry described below.
 
-This works gret for single commits, but the project tradition is to squash multiple changes.
+This works great for single commits, but the project tradition is to squash multiple changes.
 This defeats the diff index that git does. So, we'd need to mark them somehow. Keeping with
 the traditional way we've marked commits (the wisdom of which I'm not commenting on), we'd
 want to have MFCs marked like this in the commit message.
@@ -19,7 +19,7 @@ MFC: 12def6789a,ac32ee4a5c
 ```
 where the first 10 digits of the hash is used to mark the commit message. This preserves the information,
 but isn't 'git standard' which is just to have a line of text that says the commit was from hash
-whatever without the 'key: value' structure. it also wouldn't help the `git log --cherry` command, unless
+whatever without the 'key: value' structure. It also wouldn't help the `git log --cherry` command, unless
 we would use that to come up with candiates, and then use the MFC lines to weed them out.
 Altnernatively, adding a note either to the src (saying where it had been merged to) or the destination
 (saying where it had been merged from) would allow for easier parsing and after-the-fact fixups


### PR DESCRIPTION
Fixing a typo in the MFC.md file.