### PR TITLE
Use remote name 'freebsd' when fetching/merging

### DIFF
--- a/doc-cvt.md
+++ b/doc-cvt.md
@@ -142,8 +142,8 @@ The longer form is also recommended.
 ```
 % cd freebsd-doc
 % git checkout main
-% git fetch origin
-% git merge --ff-only origin/main
+% git fetch freebsd
+% git merge --ff-only freebsd/main
 ```
 These commands reset your tree to the main branch, and then update it
 from where you pulled the tree from originally. It's important to


### PR DESCRIPTION
The clone command described above is

    git clone -o freebsd ...

This means the remote name 'origin' does not exist, so users will see errors
when following

    git fetch origin
    git merge --ff-only origin/main