### PR TITLE
Use remote name 'freebsd'

### DIFF
--- a/URLs.md
+++ b/URLs.md
@@ -67,13 +67,13 @@ https://github.com/freebsd/git_conv#gimme-the-repo
 
 * Clone the repository:
   ```
-  git clone https://git.freebsd.org/${repo}.git
+  git clone -o freebsd --config remote.freebsd.fetch='+refs/notes/*:refs/notes/*' https://git.freebsd.org/${repo}.git
   ```
   Then you should have the official mirrors as your remote:
   ```
   $ git remote -v
-  origin  https://git.freebsd.org/${repo}.git (fetch)
-  origin  https://git.freebsd.org/${repo}.git (push)
+  freebsd  https://git.freebsd.org/${repo}.git (fetch)
+  freebsd  https://git.freebsd.org/${repo}.git (push)
   ```
 
 * Config the FreeBSD committer data:
@@ -91,13 +91,13 @@ https://github.com/freebsd/git_conv#gimme-the-repo
 
 * Set the push URL:
   ```
-   $ git remote set-url --push origin git@gitrepo.freebsd.org:${repo}.git
+   $ git remote set-url --push freebsd git@gitrepo.freebsd.org:${repo}.git
   ```
   Then you should have separated fetch and push URLs as the most efficient setup:
   ```
   $ git remote -v
-  origin  https://git.freebsd.org/${repo}.git (fetch)
-  origin  git@gitrepo.freebsd.org:${repo}.git (push)
+  freebsd  https://git.freebsd.org/${repo}.git (fetch)
+  freebsd  git@gitrepo.freebsd.org:${repo}.git (push)
   ```
   Again, note that `gitrepo.freebsd.org` will be canonicalized to `repo.freebsd.org` in the future.
 
@@ -108,7 +108,7 @@ The `access` and `mentors` files are stored in a orphan branch, `internal/admin`
 Following example is how to check out the `internal/admin` branch to a local branch named `admin`:
 
 ```
-git config --add remote.origin.fetch '+refs/internal/*:refs/internal/*'
+git config --add remote.freebsd.fetch '+refs/internal/*:refs/internal/*'
 git fetch
 git checkout -b admin internal/admin
 ```

--- a/design-notes.md
+++ b/design-notes.md
@@ -9,7 +9,7 @@ forthcoming.
 
 ```
 git clone https://cgit-beta.freebsd.org/src.git && cd src
-git config --add remote.origin.fetch '+refs/notes/*:refs/notes/*' && git fetch
+git config --add remote.freebsd.fetch '+refs/notes/*:refs/notes/*' && git fetch
 ```
 
 Same for the `doc` and `ports` repos. You can expect some things to be
@@ -24,12 +24,12 @@ namespace for now only has the `access` and `mentors` file, detailing when
 people got their various commit bits.
 
 ```
-git config --add remote.origin.fetch '+refs/vendor/*:refs/vendor/*'
-git config --add remote.origin.fetch '+refs/projects/*:refs/projects/*'
-git config --add remote.origin.fetch '+refs/user/*:refs/user/*'
-git config --add remote.origin.fetch '+refs/backups/*:refs/backups/*'
-git config --add remote.origin.fetch '+refs/cvs2svn/*:refs/cvs2svn/*'
-git config --add remote.origin.fetch '+refs/internal/*:refs/internal/*'
+git config --add remote.freebsd.fetch '+refs/vendor/*:refs/vendor/*'
+git config --add remote.freebsd.fetch '+refs/projects/*:refs/projects/*'
+git config --add remote.freebsd.fetch '+refs/user/*:refs/user/*'
+git config --add remote.freebsd.fetch '+refs/backups/*:refs/backups/*'
+git config --add remote.freebsd.fetch '+refs/cvs2svn/*:refs/cvs2svn/*'
+git config --add remote.freebsd.fetch '+refs/internal/*:refs/internal/*'
 git fetch
 ```
 

--- a/faq.md
+++ b/faq.md
@@ -229,9 +229,9 @@ git reset --hard HEAD^2
 
 **Q:** But I also need to fix my 'main' branch. How do I do that?
 
-**A:** Git keeps track of the origis repository's own branches in an
-`freebsd/` namespace.  To fix your 'main' branch, just make it point to
-the origin's 'main':
+**A:** Git keeps track of the remote repository branches in a `freebsd/`
+namespace.  To fix your 'main' branch, just make it point to the remote's
+'main':
 ```
 git branch -f main freebsd/main
 ```

--- a/vendor.md
+++ b/vendor.md
@@ -12,12 +12,12 @@ their own name space, in much the same way notes are.
 
 To import notes, for example, one would	clone the repository and then do:
 ```
-git config --add remote.origin.fetch '+refs/notes/*:refs/notes/*' && git fetch
+git config --add remote.freebsd.fetch '+refs/notes/*:refs/notes/*' && git fetch
 ```
 
 To retrieve the	vendor information, one	does the following:
 ```
-git config --add remote.origin.fetch '+refs/vendor/*:refs/vendor/*' && git fetch
+git config --add remote.freebsd.fetch '+refs/vendor/*:refs/vendor/*' && git fetch
 ```
 This will pull in all the vendor relevant stuff. You should expect to
 need a fair amount of disk space for this operation. In	the future,
@@ -118,7 +118,7 @@ Now you need to update the mtree in FreeBSD. The sources live in `contrib/mtree`
 
 At this point you can push it upstream
 ```
-% git push --follow-tags origin vendor/NetBSD/mtree
+% git push --follow-tags freebsd vendor/NetBSD/mtree
 ```
 
 **NOTE:** I'm not 100% sure the above worked as intended.


### PR DESCRIPTION
Follow the convention of using the remote name 'freebsd', which is used in
other documents.