### PR TITLE
Fix remote name in "Migrating from GitHub fork"

### DIFF
--- a/src-cvt.md
+++ b/src-cvt.md
@@ -218,7 +218,7 @@ historical branches...
 
 When migrating branches from a github fork from the old github mirror
 to the official repo, the process is straight forward. This assumes that
-you have a `freebsd` upstream pointing to github, adjust if necessary.
+you have a `origin` upstream pointing to github, adjust if necessary.
 This also assumes a clean tree before starting...
 1. Add the new `freebsd` source of truth:
 ```
@@ -230,7 +230,7 @@ This also assumes a clean tree before starting...
 fetching the `freebsd` sources and creating a local `main` reference with
 the above checkout:
 ```
-% git rebase -i freebsd/master FOO --onto main
+% git rebase -i origin/master FOO --onto main
 ```
 And you'll now be tracking the official source of truth. You can then follow
 the `Keeping Current` section above to stay up to date.


### PR DESCRIPTION
The new FreeBSD repository no longer contains the old
master branch so we can't use freebsd/master in the
rebase command. Update the instructions to use
origin for the GitHub remote.