### PR TITLE
First cut at "Submitted by" / authorship recommendations

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -32,6 +32,7 @@
 
 * [Writing Good FreeBSD Commit Messages](commit.md)
 * [Include appropriate metadata in a footer](meta.md)
+* [How to deal with Pull Requests](pull-request.md)
 
 ## Design & Implementation
 

--- a/meta.md
+++ b/meta.md
@@ -5,7 +5,6 @@ Commit messages may have one or more of number of standard metadata tags in the 
 | Tag | Description |
 | -------- | -------- |
 | PR: | FreeBSD problem report (Bugzilla) number |
-| Submitted-by: | ID the original author, if not the committer |
 | Reported-by: | ID of a 3rd party who reported the issue |
 | Reviewed-by: | Reviewer ID |
 | Tested-by: | ID of those who have tested the change |
@@ -31,3 +30,5 @@ signed-off-by for commits at this time, but don't want to preclude it
 in the future.
 
 In addition, you can replace - with a space in the above tags as a transition aid.
+
+"Submitted by" may still appear, but is generally discouraged as a legacy tag. See [How to deal with Pull Requests](pull-request.md) for details on attribution.

--- a/pull-request.md
+++ b/pull-request.md
@@ -57,6 +57,8 @@ Adapt this to wherever you got the pull or merge request from.
 
 # Common ways to integrate the Pull Request
 
+## Patches in a Git repository
+
 We'll take the GitHub example, but GitLab and co. will be just the same.
 
 Run `git log github/pull/422/head` and you see 3 commits by a contributor,
@@ -89,6 +91,26 @@ Auto-merging sys/sys/errno.h
  Date: Fri Jan 24 16:31:41 2020 +0800
  1 file changed, 2 insertions(+)
 
+```
+
+## Other patches
+
+Various means exist to submit patches that do not haved metadata associated with
+them, including the patch author, e.g., Bugzilla. Previously a committer would
+commit the received patch and typically add the contributor's name and e-mail
+address in the message metadata, in the form of a "Submitted by" line.
+
+Going forward, the procedure is generally the same with exception of the
+contributor metadata. Patches should have the author set to the contributor's
+information that would have previously appeared in the "Submitted by" tag, and
+the "Submitted by" tag should be entirely omitted.
+
+```
+% git checkout -b unattributed_patch freebsd/main
+% fetch "https://.../foo.diff"
+% patch < foo.diff
+...
+% git commit --author="Submitter Name <Email Address>" ...
 ```
 
 ## Massaging the commit history and content


### PR DESCRIPTION
Perhaps a little bit strong; initial version declares "Submitted by" to be "discouraged" and a "legacy" tag.